### PR TITLE
Refactor SubmissionStatus enum values from integers to strings

### DIFF
--- a/competitions/enums.py
+++ b/competitions/enums.py
@@ -2,11 +2,11 @@ import enum
 
 
 class SubmissionStatus(enum.Enum):
-    PENDING = 0
-    QUEUED = 1
-    PROCESSING = 2
-    SUCCESS = 3
-    FAILED = 4
+    PENDING = "pending"
+    QUEUED = "queued"
+    PROCESSING = "processing"
+    SUCCESS = "success"
+    FAILED = "failed"
 
 
 class CompetitionType(enum.Enum):


### PR DESCRIPTION
This is my first pull request, so I apologize if there are any mistakes.

To make it more readable for competition participants, we suggest changing the SubmissionStatus from numbers to words.

Currently, we are hosting a private competition within the company. However, there was a change in the Status midway, which confused the participants.

<img width="1293" alt="スクリーンショット 2024-02-09 13 59 18" src="https://github.com/huggingface/competitions/assets/5457315/5004925f-2493-475e-a3c3-0a0ac57210c6">
