### PR TITLE
Fix typo of sample JSON file

### DIFF
--- a/docs/source/competition_repo.mdx
+++ b/docs/source/competition_repo.mdx
@@ -49,7 +49,7 @@ conf.json is the configuration file for the competition. An example conf.json is
    "EVAL_METRIC":"roc_auc_score",
    "LOGO":"https://github.com/abhishekkrthakur/public_images/blob/main/song.png?raw=true",
    "DATASET": "",
-   "SUBMISSION_FILENAMES": ["submission.csv"]
+   "SUBMISSION_FILENAMES": ["submission.csv"],
    "SCORING_METRIC": "roc_auc_score"
 }
 ```


### PR DESCRIPTION
I found that a comma dropped in a sample JSON and added one in a right place