### PR TITLE
feat: use seccomp to block network

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update &&  \
     libgl1 \
     unzip \
     openjdk-11-jre-headless \
+    libseccomp-dev \
     && rm -rf /var/lib/apt/lists/* && \
     apt-get clean
 
@@ -68,7 +69,7 @@ RUN conda install pytorch torchvision torchaudio pytorch-cuda=12.1 -c pytorch -c
     conda install -c "nvidia/label/cuda-12.1.0" cuda-nvcc && conda clean -ya
 
 COPY --chown=1000:1000 . /app/
-RUN make socket-kit.so
+RUN make sandbox
 
 ENV PATH="/app:${PATH}"
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-CFLAGS += -std=c99 -Wall
+CFLAGS += -std=c99 -Wall -O2
+LDFLAGS += -lseccomp
 .PHONY: quality style test
 
 quality:
@@ -18,11 +19,11 @@ docker:
 test:
 	pytest -sv .
 
-socket-kit.so: socket-kit.c
-	gcc $(CFLAGS) -shared -fPIC $^ -o $@ -ldl
+sandbox: sandbox.c
+	gcc $(CFLAGS) $^ -o $@ $(LDFLAGS)
 
 clean:
-	rm *.so
+	rm *.so sandbox
 
 pip:
 	rm -rf build/

--- a/competitions/evaluate.py
+++ b/competitions/evaluate.py
@@ -60,9 +60,7 @@ def generate_submission_file(params):
     try:
         process.wait(timeout=params.time_limit)
     except subprocess.TimeoutExpired:
-        logger.info(
-            f"Process exceeded {params.time_limit} seconds time limit. Terminating..."
-        )
+        logger.info(f"Process exceeded {params.time_limit} seconds time limit. Terminating...")
         process.kill()
         process.wait()
 
@@ -122,9 +120,7 @@ def run(params):
 
     evaluation = compute_metrics(params)
 
-    utils.update_submission_score(
-        params, evaluation["public_score"], evaluation["private_score"]
-    )
+    utils.update_submission_score(params, evaluation["public_score"], evaluation["private_score"])
     utils.update_submission_status(params, SubmissionStatus.SUCCESS.value)
     utils.delete_space(params)
 

--- a/competitions/evaluate.py
+++ b/competitions/evaluate.py
@@ -43,18 +43,15 @@ def generate_submission_file(params):
     # invalidate USER_TOKEN env var
     os.environ["USER_TOKEN"] = ""
 
-    # Copy socket-kit.so to submission_dir
-    shutil.copyfile("socket-kit.so", f"{submission_dir}/socket-kit.so")
+    # Copy sandbox to submission_dir
+    shutil.copyfile("sandbox", f"{submission_dir}/sandbox")
 
     # Define your command
-    cmd = "python script.py"
-    socket_kit_path = os.path.abspath(f"{submission_dir}/socket-kit.so")
+    cmd = "./sandbox python script.py"
+    cmd = shlex.split(cmd)
 
     # Copy the current environment and modify it
     env = os.environ.copy()
-    env["LD_PRELOAD"] = socket_kit_path
-
-    cmd = shlex.split(cmd)
 
     # Start the subprocess
     process = subprocess.Popen(cmd, cwd=submission_dir, env=env)
@@ -63,7 +60,9 @@ def generate_submission_file(params):
     try:
         process.wait(timeout=params.time_limit)
     except subprocess.TimeoutExpired:
-        logger.info(f"Process exceeded {params.time_limit} seconds time limit. Terminating...")
+        logger.info(
+            f"Process exceeded {params.time_limit} seconds time limit. Terminating..."
+        )
         process.kill()
         process.wait()
 
@@ -123,7 +122,9 @@ def run(params):
 
     evaluation = compute_metrics(params)
 
-    utils.update_submission_score(params, evaluation["public_score"], evaluation["private_score"])
+    utils.update_submission_score(
+        params, evaluation["public_score"], evaluation["private_score"]
+    )
     utils.update_submission_status(params, SubmissionStatus.SUCCESS.value)
     utils.delete_space(params)
 

--- a/sandbox.c
+++ b/sandbox.c
@@ -1,0 +1,53 @@
+#include <errno.h>
+#include <seccomp.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char* argv[]) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <command> [args...]\n", argv[0]);
+        return EXIT_FAILURE;
+    }
+
+    scmp_filter_ctx ctx;
+
+    // Initialize the seccomp filter in blocklist mode
+    ctx = seccomp_init(SCMP_ACT_ALLOW);
+    if (ctx == NULL) {
+        perror("seccomp_init");
+        return EXIT_FAILURE;
+    }
+
+    // Block network-related syscalls
+    seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(socket), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(connect), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(bind), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(listen), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(accept), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(send), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(sendto), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(sendmsg), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(recv), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(recvfrom), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(recvmsg), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(setsockopt), 0);
+    seccomp_rule_add(ctx, SCMP_ACT_ERRNO(EPERM), SCMP_SYS(getsockopt), 0);
+
+    // Load the filter into the kernel
+    if (seccomp_load(ctx) < 0) {
+        perror("seccomp_load");
+        seccomp_release(ctx);
+        return EXIT_FAILURE;
+    }
+
+#ifdef DEBUG
+    printf("seccomp filter installed. Network access is blocked.\n");
+#endif
+
+    // Execute the target program
+    execvp(argv[1], argv + 1);
+
+    seccomp_release(ctx);
+    return EXIT_SUCCESS;
+}

--- a/socket-kit.c
+++ b/socket-kit.c
@@ -1,8 +1,0 @@
-#include <errno.h>
-#include <sys/socket.h>
-
-int connect(int fd, const struct sockaddr *addr, socklen_t len)
-{
-    errno = ENETDOWN;
-    return -1;
-}


### PR DESCRIPTION
Currently, the network blocking mechanism is using `LD_PRELOAD` to overwrite the `connect` function in the standard library, which causes some problems. For example, `script.py` can clear the environment and call another process to leak the dataset.

I rewrote the sandbox using `seccomp` to block network-related functions, which affects all child processes and makes the execution environment more restrictive.
