### PR TITLE
Make submission dialogue explain the error in detail

### DIFF
--- a/competitions/app.py
+++ b/competitions/app.py
@@ -3,6 +3,8 @@ import os
 import threading
 import time
 
+from requests.exceptions import RequestException
+
 from fastapi import Depends, FastAPI, File, Form, HTTPException, Request, UploadFile
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
@@ -302,10 +304,14 @@ async def new_submission(
         if competition_info.competition_type == "script":
             resp = sub.new_submission(user_token, hub_model, submission_comment)
             return {"response": f"Success! You have {resp} submissions remaining today."}
+    except RequestException:
+        return {"response": "Hugging Face Hub is unreachable, please try again later"}
     except AuthenticationError:
         return {"response": "Invalid token"}
     except PastDeadlineError:
-        return {"response": "Competition has ended."}
+        return {"response": "Competition has ended"}
+    except SubmissionError:
+        return {"response": "Invalid submission file"}
     except SubmissionLimitError:
         return {"response": "Submission limit reached"}
     return {"response": "Invalid competition type"}

--- a/competitions/app.py
+++ b/competitions/app.py
@@ -302,6 +302,8 @@ async def new_submission(
         if competition_info.competition_type == "script":
             resp = sub.new_submission(user_token, hub_model, submission_comment)
             return {"response": f"Success! You have {resp} submissions remaining today."}
+    except AuthenticationError:
+        return {"response": "Invalid token"}
     except PastDeadlineError:
         return {"response": "Competition has ended."}
     except SubmissionLimitError:

--- a/competitions/app.py
+++ b/competitions/app.py
@@ -302,8 +302,13 @@ async def new_submission(
         if competition_info.competition_type == "script":
             resp = sub.new_submission(user_token, hub_model, submission_comment)
             return {"response": f"Success! You have {resp} submissions remaining today."}
-    except AuthenticationError:
-        return {"response": "Invalid token"}
+    except (
+        AuthenticationError,
+        PastDeadlineError,
+        SubmissionError,
+        SubmissionLimitError
+    ) as e:
+        return {"response": e}
     return {"response": "Invalid competition type"}
 
 

--- a/competitions/app.py
+++ b/competitions/app.py
@@ -302,13 +302,10 @@ async def new_submission(
         if competition_info.competition_type == "script":
             resp = sub.new_submission(user_token, hub_model, submission_comment)
             return {"response": f"Success! You have {resp} submissions remaining today."}
-    except (
-        AuthenticationError,
-        PastDeadlineError,
-        SubmissionError,
-        SubmissionLimitError
-    ) as e:
-        return {"response": e}
+    except PastDeadlineError:
+        return {"response": "Competition has ended."}
+    except SubmissionLimitError:
+        return {"response": "Submission limit reached"}
     return {"response": "Invalid competition type"}
 
 


### PR DESCRIPTION
Current submission dialogues output unreadble error messages like below for some exceptions:

<img width="476" alt="screenshot 2024-10-20 at 17 57 19" src="https://github.com/user-attachments/assets/ddc63e41-369b-47b0-8349-ba57532c5d9c">

This pull request passes the exception message from Submission.new_submission() to submission dialogues to be more user-friendly.