### PR TITLE
bug fix: preventing updating submission status with a non-integer value

### DIFF
--- a/competitions/utils.py
+++ b/competitions/utils.py
@@ -223,7 +223,7 @@ def update_submission_score(params, public_score, private_score):
         if submission["submission_id"] == params.submission_id:
             submission["public_score"] = public_score
             submission["private_score"] = private_score
-            submission["status"] = "done"
+            submission["status"] = SubmissionStatus.SUCCESS.value
             break
     upload_submission_info(params, user_submission_info)
 


### PR DESCRIPTION
The `status` field in submission_info is supposed to be an integer defined by the `SubmissionStatus` class, but there was one place in the script where the status was still being overwritten with the string "done". This occasionally caused an error where the leaderboard would not display correctly.
Therefore, this pull request fixes the issue by replacing the string assignment with `SubmissionStatus.SUCCESS.value`, thus preventing the bug where status could become a non-integer value.