### PR TITLE
Fix Safari ITP submission failure on /new_submission

### DIFF
--- a/competitions/templates/index.html
+++ b/competitions/templates/index.html
@@ -815,9 +815,11 @@
             var submissionComment = document.getElementById('submission_comment').value;
             formData.append('submission_comment', submissionComment);
 
-            fetch('/new_submission', {
-                method: 'POST',
-                body: formData
+            const __sign = new URLSearchParams(window.location.search).get('__sign');
+            fetch('/new_submission' + (__sign ? '?__sign=' + __sign : ''), {
+               method: 'POST',
+               credentials: 'include',
+               body: formData
             })
                 .then(response => response.json())
                 .then(data => {


### PR DESCRIPTION
On Safari, the HF Space proxy requires the `__sign` JWT token to authenticate requests. Safari's Intelligent Tracking Prevention (ITP) blocks the session cookie that Chrome uses, so POST requests to `/new_submission` are rejected by the proxy before reaching `uvicorn`, returning an HTML 401 instead of JSON. `response.json()` then throws `SyntaxError: The string did not match the expected pattern` (Safari's wording for a JSON parse failure).

Fix: Extract `__sign` from the current page URL and forward it on the POST, plus add credentials: 'include' to ensure cookies are sent where available.